### PR TITLE
Add text_value completion field, habit archived flag, and new habit t…

### DIFF
--- a/Repositories/completion-tracker-repo.js
+++ b/Repositories/completion-tracker-repo.js
@@ -1,9 +1,9 @@
 import pool from '../db/db.js'
 
-export async function create({ habitId, date, selectedTag, value }) {
+export async function create({ habitId, date, selectedTag, value, textValue }) {
   const result = await pool.query(
-    'INSERT INTO completions (habit_id, date, selected_tag, value) VALUES ($1, $2, $3, $4) RETURNING *',
-    [habitId, date, selectedTag, value]
+    'INSERT INTO completions (habit_id, date, selected_tag, value, text_value) VALUES ($1, $2, $3, $4, $5) RETURNING *',
+    [habitId, date, selectedTag, value, textValue]
   )
   return result.rows[0]
 }
@@ -56,10 +56,10 @@ export async function findByHabit(habitId) {
 }
 
 export async function update(id, updates) {
-  const { selectedTag, value } = updates
+  const { selectedTag, value, textValue } = updates
   const result = await pool.query(
-    'UPDATE completions SET selected_tag = $1, value = $2, updated_at = NOW() WHERE completion_id = $3 RETURNING *',
-    [selectedTag, value, id]
+    'UPDATE completions SET selected_tag = $1, value = $2, text_value = $3, updated_at = NOW() WHERE completion_id = $4 RETURNING *',
+    [selectedTag, value, textValue, id]
   )
   return result.rows[0] ?? null
 }

--- a/Repositories/habit-repo.js
+++ b/Repositories/habit-repo.js
@@ -27,13 +27,13 @@ export async function findByUserId(userId) {
 }
 
 export async function update(id, updates) {
-  const { name, target, type, availableTags, sliderMin, colorLow, colorMid, colorHigh, recurrence } = updates
+  const { name, target, type, availableTags, sliderMin, colorLow, colorMid, colorHigh, recurrence, archived } = updates
 
   const result = await pool.query(
     `UPDATE habits SET name = $1, target = $2, type = $3, available_tags = $4, slider_min = $5,
-     color_low = $6, color_mid = $7, color_high = $8, recurrence_interval = $9, recurrence_days = $10, updated_at = NOW()
-     WHERE habit_id = $11 RETURNING *`,
-    [name, target, type, availableTags, sliderMin, colorLow, colorMid, colorHigh, recurrence?.interval, recurrence?.days, id]
+     color_low = $6, color_mid = $7, color_high = $8, recurrence_interval = $9, recurrence_days = $10, archived = $11, updated_at = NOW()
+     WHERE habit_id = $12 RETURNING *`,
+    [name, target, type, availableTags, sliderMin, colorLow, colorMid, colorHigh, recurrence?.interval, recurrence?.days, archived, id]
   )
   return result.rows[0] ?? null
 }

--- a/Services/completion-tracker-service.js
+++ b/Services/completion-tracker-service.js
@@ -9,12 +9,14 @@ export const createCompletionSchema = z.object({
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   selectedTag: z.string().optional().nullable(),
   value: z.number().optional().nullable(),
+  textValue: z.string().optional().nullable(),
 });
 
 export const updateCompletionSchema = z
   .object({
     selectedTag: z.string().optional().nullable(),
     value: z.number().optional().nullable(),
+    textValue: z.string().optional().nullable(),
   })
   .refine((data) => Object.keys(data).length > 0, {
     message: "Need at least one field to update",
@@ -30,6 +32,7 @@ export async function createCompletion({
   date,
   selectedTag,
   value,
+  textValue,
 }) {
   const user = await userRepo.findById(userId);
   if (!user) {
@@ -54,6 +57,7 @@ export async function createCompletion({
     return await completionRepo.update(existingCompletion.completion_id, {
       selectedTag,
       value,
+      textValue,
     });
   }
 
@@ -62,6 +66,7 @@ export async function createCompletion({
     date,
     selectedTag,
     value,
+    textValue,
   });
 }
 

--- a/Services/habit-service.js
+++ b/Services/habit-service.js
@@ -6,7 +6,7 @@ export const createHabitSchema = z.object({
   name: z.string(),
   target: z.number(),
   type: z
-    .enum(["checkbox", "counter", "duration", "slider"])
+    .enum(["checkbox", "counter", "duration", "slider", "rating", "checknote", "shorttext", "journal"])
     .default("checkbox"),
   availableTags: z.array(z.string()).default([]),
   createdAt: z.coerce.date().optional(),
@@ -33,13 +33,14 @@ export const updateHabitSchema = z
   .object({
     userId: z.string().optional(),
     name: z.string().optional(),
-    type: z.enum(["checkbox", "counter", "duration", "slider"]).optional(),
+    type: z.enum(["checkbox", "counter", "duration", "slider", "rating", "checknote", "shorttext", "journal"]).optional(),
     target: z.number().optional(),
     availableTags: z.array(z.string()).optional(),
     sliderMin: z.number().optional().nullable(),
     colorLow: z.string().optional().nullable(),
     colorMid: z.string().optional().nullable(),
     colorHigh: z.string().optional().nullable(),
+    archived: z.boolean().optional(),
     recurrence: z
       .object({
         interval: z.number().int().min(1),
@@ -117,6 +118,7 @@ export async function updateHabit(id, updates) {
     colorLow: updates.colorLow ?? existing.color_low,
     colorMid: updates.colorMid ?? existing.color_mid,
     colorHigh: updates.colorHigh ?? existing.color_high,
+    archived: updates.archived ?? existing.archived,
     recurrence: updates.recurrence ?? {
       interval: existing.recurrence_interval,
       days: existing.recurrence_days,

--- a/db/migrations/0001_add_text_value_and_archived.sql
+++ b/db/migrations/0001_add_text_value_and_archived.sql
@@ -1,0 +1,7 @@
+-- Additive, backward-compatible schema changes:
+-- 1. completions.text_value — free-text completion value (used by checknote/shorttext/journal habit types)
+-- 2. habits.archived — pause/archive a habit without deleting its history
+
+ALTER TABLE completions ADD COLUMN IF NOT EXISTS text_value TEXT;
+
+ALTER TABLE habits ADD COLUMN IF NOT EXISTS archived BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
…ypes

Adds two additive, backward-compatible schema changes to support new frontend features: a nullable text_value column on completions for free-text entries, and an archived boolean on habits to pause a habit without deleting its history. Also extends the habit type enum with rating, checknote, shorttext, and journal.